### PR TITLE
got rid of sticky input and re-added scrolling behavior for messages

### DIFF
--- a/app/javascript/controllers/conversation_controller.js
+++ b/app/javascript/controllers/conversation_controller.js
@@ -4,6 +4,30 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["messages", "form", "textarea", "submit", "loadingIndicator"]
 
+  connect() {
+
+    this.scrollToBottom()
+
+    // Focus on textarea when page loads
+    if (this.hasTextareaTarget) {
+      this.textareaTarget.focus()
+    }
+
+    // Add smooth scroll behavior
+    if (this.hasMessagesTarget) {
+      this.messagesTarget.style.scrollBehavior = 'smooth'
+    }
+  }
+
+  // Auto-scroll to bottom of messages
+  scrollToBottom() {
+    if (this.hasMessagesTarget) {
+      setTimeout(() => {
+        this.messagesTarget.scrollTop = this.messagesTarget.scrollHeight
+      }, 100)
+    }
+  }
+
   // Handle Enter key to send (Shift+Enter for new line)
   handleKeydown(event) {
     if (event.key === "Enter" && !event.shiftKey) {
@@ -11,4 +35,6 @@ export default class extends Controller {
       this.formTarget.requestSubmit()
     }
   }
+
+
 }

--- a/app/views/conversations/show.html.erb
+++ b/app/views/conversations/show.html.erb
@@ -112,7 +112,7 @@
         </div>
 
         <!-- INPUT CARD -->
-        <div id="new_message_container" class="bg-white border border-base-300 rounded-xl p-5 sticky bottom-4">
+        <div id="new_message_container" class="bg-white border border-base-300 rounded-xl p-5 bottom-4">
           <%= render "conversations/form", conversation: @conversation, message: @message %>
         </div>
 


### PR DESCRIPTION
In order for turbo stimulus to work, I need to remove the sticky input card.
Additionally I re-added some of Victors scrolling behavior.

WHAT STILL NEEDS TO BE DONE:
- scroll behavior for the whole page

**OLD**
<img width="500" height="665" alt="Mobile Developer Practice Interview (Mid-level&#39;" src="https://github.com/user-attachments/assets/8fc3a75e-49d2-490a-8c20-7b8dfa04d6fb" />

**NEW**
<img width="500" height="586" alt="image" src="https://github.com/user-attachments/assets/928bdb32-cd63-480f-ae45-1efc23b2c697" />



